### PR TITLE
Add dockerfile with README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:alpine as glide
+RUN apk update
+RUN apk add git
+RUN go get github.com/Masterminds/glide
+WORKDIR /go/src/github.com/jirwin/burrow_exporter
+COPY . /go/src/github.com/jirwin/burrow_exporter
+RUN glide install
+RUN go build burrow-exporter.go
+
+FROM alpine
+COPY --from=glide /go/src/github.com/jirwin/burrow_exporter/burrow-exporter .
+ENV BURROW_ADDR http://localhost:8000
+ENV METRICS_ADDR 0.0.0.0:8080
+ENV INTERVAL 30
+CMD ./burrow-exporter --burrow-addr $BURROW_ADDR --metrics-addr $METRICS_ADDR --interval $INTERVAL

--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@
 
 A simple prometheus exporter for gathering Kafka consumer group info
 from [burrow](https://github.com/linkedin/Burrow).
+
+
+## Run with Docker
+
+### required environment variables
+#### BURROW_ADDR
+A burrow address is required. Default: http://localhost:8000
+#### METRICS_ADDR
+An address to run prometheus on is required. Default: 0.0.0.0:8080
+#### INTERVAL
+A scrape interval is required. Default: 30
+
+### Example
+```sh
+# with env variables
+docker run \
+  -e BURROW_ADDR="http://localhost:8000" \
+  -e METRICS_ADDR="0.0.0.0:8080" \
+  -e INTERVAL="30" \
+  saada/burrow_exporter
+# with custom command
+docker run -d saada/burrow_exporter ./burrow-exporter --burrow-addr http://localhost:8000 --metrics-addr 0.0.0.0:8080 --interval 30
+```


### PR DESCRIPTION
closes #1 
The image is 13.8MB in size and 5MB compressed.
You can test it here 
```
docker run \
  -e BURROW_ADDR="http://localhost:8000" \
  -e METRICS_ADDR="localhost:8001" \
  -e INTERVAL="30" \
  saada/burrow_exporter
```