### PR TITLE
Add offset and max_offset metrics

### DIFF
--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -57,6 +57,7 @@ type Offset struct {
 	Offset    int64 `json:"offset"`
 	Timestamp int64 `json:"timestamp"`
 	Lag       int64 `json:"lag"`
+	MaxOffset int64 `json:"max_offset"`
 }
 
 type ConsumerGroupStatus struct {

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -38,6 +38,20 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
 		}).Set(float64(partition.End.Lag))
+
+		KafkaConsumerPartitionCurrentOffset.With(prometheus.Labels{
+			"cluster":   status.Status.Cluster,
+			"group":     status.Status.Group,
+			"topic":     partition.Topic,
+			"partition": strconv.Itoa(int(partition.Partition)),
+		}).Set(float64(partition.End.Offset))
+
+		KafkaConsumerPartitionMaxOffset.With(prometheus.Labels{
+			"cluster":   status.Status.Cluster,
+			"group":     status.Status.Group,
+			"topic":     partition.Topic,
+			"partition": strconv.Itoa(int(partition.Partition)),
+		}).Set(float64(partition.End.MaxOffset))
 	}
 
 	KafkaConsumerTotalLag.With(prometheus.Labels{

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -10,6 +10,20 @@ var (
 		},
 		[]string{"cluster", "group", "topic", "partition"},
 	)
+	KafkaConsumerPartitionCurrentOffset = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_partition_current_offset",
+			Help: "The latest offset commit on a partition as reported by burrow.",
+		},
+		[]string{"cluster", "group", "topic", "partition"},
+	)
+	KafkaConsumerPartitionMaxOffset = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_partition_max_offset",
+			Help: "The log end offset on a partition as reported by burrow.",
+		},
+		[]string{"cluster", "group", "topic", "partition"},
+	)
 	KafkaConsumerTotalLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_total_lag",
@@ -21,5 +35,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(KafkaConsumerPartitionLag)
+	prometheus.MustRegister(KafkaConsumerPartitionCurrentOffset)
+	prometheus.MustRegister(KafkaConsumerPartitionMaxOffset)
 	prometheus.MustRegister(KafkaConsumerTotalLag)
 }


### PR DESCRIPTION
Are you interested in this pull request? In addition to lag, our burrow is giving us additional metrics that we'd like to report on:
* last committed offset of the consumer group (i.e. `offset` or `current-offset`)
* last offset of the partition, not necessarily read by the consumer group (i.e. `max-offset` or `log-end-offset`)

These can be useful when combined with Prometheus' [rate](https://prometheus.io/docs/querying/functions/#rate()) function, to see the rate of new message creation as well as the rate that messages are being processed.
