### PR TITLE
Improve app start

### DIFF
--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -103,7 +103,8 @@ func (be *BurrowExporter) Start(ctx context.Context) {
 }
 
 func (be *BurrowExporter) scrape() {
-	log.WithField("timestamp", time.Now().UnixNano()).Info("Scraping burrow...")
+	start := time.Now()
+	log.WithField("timestamp", start.UnixNano()).Info("Scraping burrow...")
 	clusters, err := be.client.ListClusters()
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -125,7 +126,11 @@ func (be *BurrowExporter) scrape() {
 
 	wg.Wait()
 
-	log.WithField("timestamp", time.Now().UnixNano()).Info("Finished scraping burrow.")
+	end := time.Now()
+	log.WithFields(log.Fields{
+		"timestamp": end.UnixNano(),
+		"took":      end.Sub(start),
+	}).Info("Finished scraping burrow.")
 }
 
 func (be *BurrowExporter) mainLoop(ctx context.Context) {

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -102,8 +102,37 @@ func (be *BurrowExporter) Start(ctx context.Context) {
 	be.mainLoop(ctx)
 }
 
+func (be *BurrowExporter) scrape() {
+	log.WithField("timestamp", time.Now().UnixNano()).Info("Scraping burrow...")
+	clusters, err := be.client.ListClusters()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Error("error listing clusters. Continuing.")
+		return
+	}
+
+	wg := sync.WaitGroup{}
+
+	for _, cluster := range clusters.Clusters {
+		wg.Add(1)
+
+		go func(c string) {
+			defer wg.Done()
+			be.processCluster(c)
+		}(cluster)
+	}
+
+	wg.Wait()
+
+	log.WithField("timestamp", time.Now().UnixNano()).Info("Finished scraping burrow.")
+}
+
 func (be *BurrowExporter) mainLoop(ctx context.Context) {
 	timer := time.NewTicker(time.Duration(be.interval) * time.Second)
+
+	// scrape at app start without waiting for the first interval to elapse
+	be.scrape()
 
 	for {
 		select {
@@ -113,29 +142,7 @@ func (be *BurrowExporter) mainLoop(ctx context.Context) {
 			return
 
 		case <-timer.C:
-			log.WithField("timestamp", time.Now().UnixNano()).Info("Scraping burrow...")
-			clusters, err := be.client.ListClusters()
-			if err != nil {
-				log.WithFields(log.Fields{
-					"err": err,
-				}).Error("error listing clusters. Continuing.")
-				continue
-			}
-
-			wg := sync.WaitGroup{}
-
-			for _, cluster := range clusters.Clusters {
-				wg.Add(1)
-
-				go func(c string) {
-					defer wg.Done()
-					be.processCluster(c)
-				}(cluster)
-			}
-
-			wg.Wait()
-
-			log.WithField("timestamp", time.Now().UnixNano()).Info("Finished scraping burrow.")
+			be.scrape()
 		}
 	}
 }


### PR DESCRIPTION
Two tiny changes:
* start the first scrape of burrow as soon as the app is started, instead of having to wait for the first interval to elapse
* add the time taken to the "finished scraping" log message