### PR TITLE
Add a metric for plain topic offsets

### DIFF
--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -31,6 +31,13 @@ var (
 		},
 		[]string{"cluster", "group"},
 	)
+	KafkaTopicPartitionOffset = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_topic_partition_offset",
+			Help: "The latest offset on a topic's partition as reported by burrow.",
+		},
+		[]string{"cluster", "topic", "partition"},
+	)
 )
 
 func init() {
@@ -38,4 +45,5 @@ func init() {
 	prometheus.MustRegister(KafkaConsumerPartitionCurrentOffset)
 	prometheus.MustRegister(KafkaConsumerPartitionMaxOffset)
 	prometheus.MustRegister(KafkaConsumerTotalLag)
+	prometheus.MustRegister(KafkaTopicPartitionOffset)
 }


### PR DESCRIPTION
This adds a new metric `kafka_burrow_topic_partition_offset` that gives the offsets of topics (by partition). This allows monitoring topic growth, even if the topic is not currently consumed by a consumer group (all other metrics have to do with consumer groups).