### PR TITLE
Add support for Burrow API v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as glide
+FROM golang:1.9.2-alpine3.6@sha256:577cd4aa00e214b007d12d8b4c9edd2ef096794366ec9afbc7eb2daf9da61744 as glide
 RUN apk update
 RUN apk add git
 RUN go get github.com/Masterminds/glide

--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -149,7 +149,7 @@ func (bc *BurrowClient) HealthCheck() (bool, error) {
 }
 
 func (bc *BurrowClient) ListClusters() (*ClustersResp, error) {
-	endpoint, err := bc.buildUrl("/v2/kafka")
+	endpoint, err := bc.buildUrl("/v3/kafka")
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (bc *BurrowClient) ListClusters() (*ClustersResp, error) {
 }
 
 func (bc *BurrowClient) ClusterDetails(cluster string) (*ClusterDetailsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s", cluster))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s", cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (bc *BurrowClient) ClusterDetails(cluster string) (*ClusterDetailsResp, err
 }
 
 func (bc *BurrowClient) ListConsumers(cluster string) (*ConsumerGroupsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer", cluster))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/consumer", cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (bc *BurrowClient) ListConsumers(cluster string) (*ConsumerGroupsResp, erro
 }
 
 func (bc *BurrowClient) ListConsumerTopics(cluster, consumerGroup string) (*TopicsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/topic", cluster, consumerGroup))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/consumer/%s/topic", cluster, consumerGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (bc *BurrowClient) ListConsumerTopics(cluster, consumerGroup string) (*Topi
 }
 
 func (bc *BurrowClient) ListClusterTopics(cluster string) (*TopicsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/topic", cluster))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/topic", cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (bc *BurrowClient) ListClusterTopics(cluster string) (*TopicsResp, error) {
 }
 
 func (bc *BurrowClient) ConsumerGroupTopicDetails(cluster, consumerGroup, topic string) (*ConsumerGroupTopicDetailsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/topic/%s", cluster, consumerGroup, topic))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/consumer/%s/topic/%s", cluster, consumerGroup, topic))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (bc *BurrowClient) ConsumerGroupTopicDetails(cluster, consumerGroup, topic 
 }
 
 func (bc *BurrowClient) ConsumerGroupStatus(cluster, consumerGroup string) (*ConsumerGroupStatusResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/status", cluster, consumerGroup))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/consumer/%s/status", cluster, consumerGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (bc *BurrowClient) ConsumerGroupStatus(cluster, consumerGroup string) (*Con
 }
 
 func (bc *BurrowClient) ConsumerGroupLag(cluster, consumerGroup string) (*ConsumerGroupStatusResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/lag", cluster, consumerGroup))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/consumer/%s/lag", cluster, consumerGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (bc *BurrowClient) ConsumerGroupLag(cluster, consumerGroup string) (*Consum
 }
 
 func (bc *BurrowClient) ClusterTopicDetails(cluster, topic string) (*ClusterTopicDetailsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/topic/%s", cluster, topic))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/v3/kafka/%s/topic/%s", cluster, topic))
 	if err != nil {
 		return nil, err
 	}

--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -64,7 +64,7 @@ type ConsumerGroupStatus struct {
 	Cluster    string      `json:"cluster"`
 	Group      string      `json:"group"`
 	Status     string      `json:"status"`
-	Complete   bool        `json:"complete"`
+	Complete   float32     `json:"complete"`
 	MaxLag     Partition   `json:"maxlag"`
 	Partitions []Partition `json:"partitions"`
 	TotalLag   int64       `json:"totallag"`


### PR DESCRIPTION
Extremely quick shot at https://github.com/jirwin/burrow_exporter/issues/8 to have something to scrape in https://github.com/Yolean/kubernetes-kafka/pull/125.

The only useful value in `:8080/metrics` after the initial commit is `kafka_burrow_topic_partition_offset`.