### PR TITLE
Adjusting API version support to be backwards compatible

### DIFF
--- a/burrow-exporter.go
+++ b/burrow-exporter.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jirwin/burrow_exporter/burrow_exporter"
 )
 
-var Version = "0.0.3"
+var Version = "0.0.4"
 
 func main() {
 	app := cli.NewApp()
@@ -32,6 +32,11 @@ func main() {
 		cli.IntFlag{
 			Name:  "interval",
 			Usage: "The interval(seconds) specifies how often to scrape burrow.",
+		},
+		cli.IntFlag{
+			Name:  "api-version",
+			Usage: "Burrow API version to leverage",
+			Value: 2,
 		},
 	}
 
@@ -57,7 +62,7 @@ func main() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		exporter := burrow_exporter.MakeBurrowExporter(c.String("burrow-addr"), c.String("metrics-addr"), c.Int("interval"))
+		exporter := burrow_exporter.MakeBurrowExporter(c.String("burrow-addr"), c.Int("api-version"), c.String("metrics-addr"), c.Int("interval"))
 		go exporter.Start(ctx)
 
 		<-done

--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -64,7 +64,6 @@ type ConsumerGroupStatus struct {
 	Cluster    string      `json:"cluster"`
 	Group      string      `json:"group"`
 	Status     string      `json:"status"`
-	Complete   bool        `json:"complete"`
 	MaxLag     Partition   `json:"maxlag"`
 	Partitions []Partition `json:"partitions"`
 	TotalLag   int64       `json:"totallag"`
@@ -89,8 +88,9 @@ type ClusterTopicDetailsResp struct {
 }
 
 type BurrowClient struct {
-	baseUrl string
-	client  *http.Client
+	baseUrl    string
+	apiversion int
+	client     *http.Client
 }
 
 func (bc *BurrowClient) buildUrl(endpoint string) (string, error) {
@@ -149,7 +149,7 @@ func (bc *BurrowClient) HealthCheck() (bool, error) {
 }
 
 func (bc *BurrowClient) ListClusters() (*ClustersResp, error) {
-	endpoint, err := bc.buildUrl("/v2/kafka")
+	endpoint, err := bc.buildUrl("/kafka")
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (bc *BurrowClient) ListClusters() (*ClustersResp, error) {
 }
 
 func (bc *BurrowClient) ClusterDetails(cluster string) (*ClusterDetailsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s", cluster))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s", cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (bc *BurrowClient) ClusterDetails(cluster string) (*ClusterDetailsResp, err
 }
 
 func (bc *BurrowClient) ListConsumers(cluster string) (*ConsumerGroupsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer", cluster))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/consumer", cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (bc *BurrowClient) ListConsumers(cluster string) (*ConsumerGroupsResp, erro
 }
 
 func (bc *BurrowClient) ListConsumerTopics(cluster, consumerGroup string) (*TopicsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/topic", cluster, consumerGroup))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/consumer/%s/topic", cluster, consumerGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (bc *BurrowClient) ListConsumerTopics(cluster, consumerGroup string) (*Topi
 }
 
 func (bc *BurrowClient) ListClusterTopics(cluster string) (*TopicsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/topic", cluster))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/topic", cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (bc *BurrowClient) ListClusterTopics(cluster string) (*TopicsResp, error) {
 }
 
 func (bc *BurrowClient) ConsumerGroupTopicDetails(cluster, consumerGroup, topic string) (*ConsumerGroupTopicDetailsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/topic/%s", cluster, consumerGroup, topic))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/consumer/%s/topic/%s", cluster, consumerGroup, topic))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (bc *BurrowClient) ConsumerGroupTopicDetails(cluster, consumerGroup, topic 
 }
 
 func (bc *BurrowClient) ConsumerGroupStatus(cluster, consumerGroup string) (*ConsumerGroupStatusResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/status", cluster, consumerGroup))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/consumer/%s/status", cluster, consumerGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (bc *BurrowClient) ConsumerGroupStatus(cluster, consumerGroup string) (*Con
 }
 
 func (bc *BurrowClient) ConsumerGroupLag(cluster, consumerGroup string) (*ConsumerGroupStatusResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/consumer/%s/lag", cluster, consumerGroup))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/consumer/%s/lag", cluster, consumerGroup))
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (bc *BurrowClient) ConsumerGroupLag(cluster, consumerGroup string) (*Consum
 }
 
 func (bc *BurrowClient) ClusterTopicDetails(cluster, topic string) (*ClusterTopicDetailsResp, error) {
-	endpoint, err := bc.buildUrl(fmt.Sprintf("/v2/kafka/%s/topic/%s", cluster, topic))
+	endpoint, err := bc.buildUrl(fmt.Sprintf("/kafka/%s/topic/%s", cluster, topic))
 	if err != nil {
 		return nil, err
 	}
@@ -401,9 +401,10 @@ func (bc *BurrowClient) ClusterTopicDetails(cluster, topic string) (*ClusterTopi
 	return topicDetails, nil
 }
 
-func MakeBurrowClient(baseUrl string) *BurrowClient {
+func MakeBurrowClient(baseUrl string, apiVersion int) *BurrowClient {
 	return &BurrowClient{
-		baseUrl: baseUrl,
+		baseUrl:    fmt.Sprintf("%s/v%d", baseUrl, apiVersion),
+		apiversion: apiVersion,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -189,9 +189,9 @@ func (be *BurrowExporter) mainLoop(ctx context.Context) {
 	}
 }
 
-func MakeBurrowExporter(burrowUrl string, metricsAddr string, interval int) *BurrowExporter {
+func MakeBurrowExporter(burrowUrl string, apiVersion int, metricsAddr string, interval int) *BurrowExporter {
 	return &BurrowExporter{
-		client:            MakeBurrowClient(burrowUrl),
+		client:            MakeBurrowClient(burrowUrl, apiVersion),
 		metricsListenAddr: metricsAddr,
 		interval:          interval,
 	}


### PR DESCRIPTION
Just a riff on what @solsson had been working on #9 to support both v2 and v3 endpoints.  

The `Complete` attribute from the `ConsumerGroupStatus` has changed types (bool -> float32) however it's not actually used so I have just removed it from the parsing to make cross version support easier. 

As someone else noted, there is no `MaxLag` attribute returned any longer, but since it's simply not present it doesn't break the unmarshal and with no metric actually being populated, it's simply not present via the prometheus endpoint. 