### PR TITLE
Update readme for v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ COPY --from=glide /go/src/github.com/jirwin/burrow_exporter/burrow-exporter .
 ENV BURROW_ADDR http://localhost:8000
 ENV METRICS_ADDR 0.0.0.0:8080
 ENV INTERVAL 30
-CMD ./burrow-exporter --burrow-addr $BURROW_ADDR --metrics-addr $METRICS_ADDR --interval $INTERVAL
+ENV API_VERSION 2
+CMD ./burrow-exporter --burrow-addr $BURROW_ADDR --metrics-addr $METRICS_ADDR --interval $INTERVAL --api-version $API_VERSION

--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@ An address to run prometheus on is required. Default: 0.0.0.0:8080
 #### INTERVAL
 A scrape interval is required. Default: 30
 
+#### API_VERSION
+Burrow API version to leverage (default: 2)
+
 ### Example
+
 ```sh
+# build docker image
+docker build -t burrow_exporter .
+
 # with env variables
-docker run \
+docker run -d -p 8080:8080 \
   -e BURROW_ADDR="http://localhost:8000" \
   -e METRICS_ADDR="0.0.0.0:8080" \
   -e INTERVAL="30" \
-  saada/burrow_exporter
+  -e API_VERSION="2" \
+  burrow_exporter
 # with custom command
-docker run -d saada/burrow_exporter ./burrow-exporter --burrow-addr http://localhost:8000 --metrics-addr 0.0.0.0:8080 --interval 30
+docker run -d burrow_exporter -p 8080:8080 ./burrow-exporter --burrow-addr http://localhost:8000 --metrics-addr 0.0.0.0:8080 --interval 30 --api-version 2
 ```


### PR DESCRIPTION
Hello.
Current README does not know whether burrow_exporter corresponds to api v3.
Add a description of api-version.
Also, the image of `saada/burrow_exporter` is not the latest version.
Change the description of README to how to build docker image locally.