### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ docker run -d -p 8080:8080 \
   -e API_VERSION="2" \
   burrow_exporter
 # with custom command
-docker run -d burrow_exporter -p 8080:8080 ./burrow-exporter --burrow-addr http://localhost:8000 --metrics-addr 0.0.0.0:8080 --interval 30 --api-version 2
+docker run -d -p 8080:8080 burrow_exporter ./burrow-exporter --burrow-addr http://localhost:8000 --metrics-addr 0.0.0.0:8080 --interval 30 --api-version 2
+
 ```


### PR DESCRIPTION
The port parameter must be changed, in the place that is documented, an error is showed:
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"-p\": executable file not found in $PATH".