### PR TITLE
Export partition status

### DIFF
--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -22,6 +22,8 @@ type BurrowExporter struct {
 	wg                sync.WaitGroup
 }
 
+var partitionStatuses = []string{"OK", "WARNING", "STALL", "STOP", "ERROR"}
+
 func (be *BurrowExporter) processGroup(cluster, group string) {
 	status, err := be.client.ConsumerGroupLag(cluster, group)
 	if err != nil {
@@ -52,6 +54,20 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
 		}).Set(float64(partition.End.MaxOffset))
+
+		for _, partitionStatus := range partitionStatuses {
+			value := 0
+			if partitionStatus == partition.Status {
+				value = 1
+			}
+			KafkaConsumerPartitionStatus.With(prometheus.Labels{
+				"cluster":   status.Status.Cluster,
+				"group":     status.Status.Group,
+				"topic":     partition.Topic,
+				"partition": strconv.Itoa(int(partition.Partition)),
+				"status":    partitionStatus,
+			}).Set(float64(value))
+		}
 	}
 
 	KafkaConsumerTotalLag.With(prometheus.Labels{

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -38,6 +38,13 @@ var (
 		},
 		[]string{"cluster", "topic", "partition"},
 	)
+	KafkaConsumerPartitionStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_partition_status",
+			Help: "The latest infos for the partition delivered in label as reported by burrow.",
+		},
+		[]string{"cluster", "topic", "group", "partition", "status"},
+	)
 )
 
 func init() {
@@ -46,4 +53,5 @@ func init() {
 	prometheus.MustRegister(KafkaConsumerPartitionMaxOffset)
 	prometheus.MustRegister(KafkaConsumerTotalLag)
 	prometheus.MustRegister(KafkaTopicPartitionOffset)
+	prometheus.MustRegister(KafkaConsumerPartitionStatus)
 }


### PR DESCRIPTION
https://github.com/jirwin/burrow_exporter/issues/11

This exports each partitions status as a time series. For every partition, there are 5 statuses. So if a partitions is `OK`, it would have these time series:
```
kafka_burrow_partition_state{cluster="MY_CLUSTER",group="MY_GROUP",partition="13",topic="MY_TOPIC",state:"OK"} 1
kafka_burrow_partition_state{cluster="MY_CLUSTER",group="MY_GROUP",partition="13",topic="MY_TOPIC",state:"STOP"} 0
kafka_burrow_partition_state{cluster="MY_CLUSTER",group="MY_GROUP",partition="13",topic="MY_TOPIC",state:"WARNING"} 0
kafka_burrow_partition_state{cluster="MY_CLUSTER",group="MY_GROUP",partition="13",topic="MY_TOPIC",state:"STALL"} 0
kafka_burrow_partition_state{cluster="MY_CLUSTER",group="MY_GROUP",partition="13",topic="MY_TOPIC",state:"ERROR"} 0
```

The reason for not having gone the enum route (mapping status to an integer):
- we'd have the mapping in many places, burrow_exporter and Grafana (if someday Burrow decide to update). Much worse at Grafana since the mapping will be can't be defined once and they'd be scattered inside every query.
- Grafana v4 (latest at that time) doesn't like this kind of mapping for tables

Table that we wanted:
![image](https://user-images.githubusercontent.com/6700692/39085137-cd19e960-4554-11e8-9cee-5acc735106e9.png)

About performance: We have more than 15k partitions running with this exporter. The number of time series is currently not an issue.

I can't look into command line flag right now, if someone would like to have this, I'm open for commits/discussion :)