### PR TITLE
#11 Export partition and group status as metrics

### DIFF
--- a/burrow-exporter.go
+++ b/burrow-exporter.go
@@ -38,6 +38,14 @@ func main() {
 			Usage: "Burrow API version to leverage",
 			Value: 2,
 		},
+		cli.BoolFlag{
+			Name: "skip-partition-status",
+			Usage: "Skip exporting the per-partition status",
+		},
+		cli.BoolFlag{
+			Name: "skip-group-status",
+			Usage: "Skip exporting the per-group status",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -62,7 +70,8 @@ func main() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		exporter := burrow_exporter.MakeBurrowExporter(c.String("burrow-addr"), c.Int("api-version"), c.String("metrics-addr"), c.Int("interval"))
+		exporter := burrow_exporter.MakeBurrowExporter(c.String("burrow-addr"), c.Int("api-version"),
+			c.String("metrics-addr"), c.Int("interval"), c.Bool("skip-partition-status"), c.Bool("skip-group-status"))
 		go exporter.Start(ctx)
 
 		<-done

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -2,6 +2,17 @@ package burrow_exporter
 
 import "github.com/prometheus/client_golang/prometheus"
 
+// If we are missing a status, it will return 0
+var Status = map[string]int{
+	"NOTFOUND": 1,
+	"OK":       2,
+	"WARN":     3,
+	"ERR":      4,
+	"STOP":     5,
+	"STALL":    6,
+	"REWIND":   7,
+}
+
 var (
 	KafkaConsumerPartitionLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -14,6 +25,13 @@ var (
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_current_offset",
 			Help: "The latest offset commit on a partition as reported by burrow.",
+		},
+		[]string{"cluster", "group", "topic", "partition"},
+	)
+	KafkaConsumerPartitionCurrentStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_partition_status",
+			Help: "The status of a partition as reported by burrow.",
 		},
 		[]string{"cluster", "group", "topic", "partition"},
 	)
@@ -31,6 +49,13 @@ var (
 		},
 		[]string{"cluster", "group"},
 	)
+	KafkaConsumerStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_status",
+			Help: "The status of a partition as reported by burrow.",
+		},
+		[]string{"cluster", "group"},
+	)
 	KafkaTopicPartitionOffset = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_topic_partition_offset",
@@ -43,7 +68,9 @@ var (
 func init() {
 	prometheus.MustRegister(KafkaConsumerPartitionLag)
 	prometheus.MustRegister(KafkaConsumerPartitionCurrentOffset)
+	prometheus.MustRegister(KafkaConsumerPartitionCurrentStatus)
 	prometheus.MustRegister(KafkaConsumerPartitionMaxOffset)
 	prometheus.MustRegister(KafkaConsumerTotalLag)
+	prometheus.MustRegister(KafkaConsumerStatus)
 	prometheus.MustRegister(KafkaTopicPartitionOffset)
 }


### PR DESCRIPTION
Adds additional flags to disable the metrics status
metrics, if desired. Left as enabled by default, even
though breaks strict backward compatibility, because
they are so useful, but are unlikely to negatively
impact many real Prometheus instances

Fix for #11