### PR TITLE
fix(KafkaConsumerPartitionLag): Use proper current lag

### DIFF
--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -70,11 +70,12 @@ type ConsumerGroupStatus struct {
 }
 
 type Partition struct {
-	Topic     string `json:"topic"`
-	Partition int32  `json:"partition"`
-	Status    string `json:"status"`
-	Start     Offset `json:"start"`
-	End       Offset `json:"end"`
+	Topic      string `json:"topic"`
+	Partition  int32  `json:"partition"`
+	Status     string `json:"status"`
+	Start      Offset `json:"start"`
+	End        Offset `json:"end"`
+	CurrentLag int64  `json:"current_lag"`
 }
 
 type ConsumerGroupStatusResp struct {

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -45,7 +45,7 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 				"group":     status.Status.Group,
 				"topic":     partition.Topic,
 				"partition": strconv.Itoa(int(partition.Partition)),
-			}).Set(float64(partition.End.Lag))
+			}).Set(float64(partition.CurrentLag))
 		}
 
 		if !be.skipPartitionCurrentOffset {


### PR DESCRIPTION
Before this fix, the latest committed lag was used for the metric, it
now uses the current lag on the partition.

Fixes #26 