### PR TITLE
Add flag to select verbosity

### DIFF
--- a/burrow-exporter.go
+++ b/burrow-exporter.go
@@ -77,6 +77,11 @@ func main() {
 			Usage:  "Skip exporting topic partition offset",
 			EnvVar: "SKIP_TOPIC_PARTITION_OFFSET",
 		},
+		cli.IntFlag{
+			Name:   "verbosity",
+			Usage:  "Set the log level",
+			EnvVar: "LOG_LEVEL",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -100,6 +105,8 @@ func main() {
 		signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
 		ctx, cancel := context.WithCancel(context.Background())
+
+		burrow_exporter.SetLogLevel(c.Int("verbosity"))
 
 		exporter := burrow_exporter.MakeBurrowExporter(
 			c.String("burrow-addr"),

--- a/burrow_exporter/log.go
+++ b/burrow_exporter/log.go
@@ -1,0 +1,24 @@
+package burrow_exporter
+
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+func SetLogLevel(mode int) {
+	switch mode {
+	case 1:
+		log.SetLevel(log.PanicLevel)
+	case 2:
+		log.SetLevel(log.FatalLevel)
+	case 3:
+		log.SetLevel(log.ErrorLevel)
+	case 4:
+		log.SetLevel(log.WarnLevel)
+	case 5:
+		log.SetLevel(log.InfoLevel)
+	case 6:
+		log.SetLevel(log.DebugLevel)
+	default:
+		log.SetLevel(log.InfoLevel)
+	}
+}


### PR DESCRIPTION
The exporter always shows the information message "Scraping rings" and "Scraping finished rings" and there is no option to show only the error messages.

This pull request add a flag to control the verbosity level of logrus using:

    1: Panic
    2: Fatal
    3: Error
    4: Warn
    5: Info
    6: Debug
    any other: Info

