### PR TITLE
Added consumer lag and offset metric to take owner (member) of consumer group

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An address to run prometheus on is required. Default: 0.0.0.0:8080
 A scrape interval is required. Default: 30
 
 #### API_VERSION
-Burrow API version to leverage (default: 2)
+Burrow API version to leverage (default: 3)
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker run -d -p 8080:8080 \
   -e BURROW_ADDR="http://localhost:8000" \
   -e METRICS_ADDR="0.0.0.0:8080" \
   -e INTERVAL="30" \
-  -e API_VERSION="2" \
+  -e API_VERSION="3" \
   burrow_exporter
 # with custom command
 docker run -d -p 8080:8080 burrow_exporter ./burrow-exporter --burrow-addr http://localhost:8000 --metrics-addr 0.0.0.0:8080 --interval 30 --api-version 2

--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -54,10 +54,11 @@ type ConsumerGroupTopicDetailsResp struct {
 }
 
 type Offset struct {
-	Offset    int64 `json:"offset"`
-	Timestamp int64 `json:"timestamp"`
-	Lag       int64 `json:"lag"`
-	MaxOffset int64 `json:"max_offset"`
+	Offset    int64  `json:"offset"`
+	Timestamp int64  `json:"timestamp"`
+	Lag       int64  `json:"lag"`
+	MaxOffset int64  `json:"max_offset"`
+	Owner     string `json:"owner"`
 }
 
 type ConsumerGroupStatus struct {
@@ -67,6 +68,7 @@ type ConsumerGroupStatus struct {
 	MaxLag     Partition   `json:"maxlag"`
 	Partitions []Partition `json:"partitions"`
 	TotalLag   int64       `json:"totallag"`
+	Owner      string      `json:"owner"`
 }
 
 type Partition struct {
@@ -76,6 +78,7 @@ type Partition struct {
 	Start      Offset `json:"start"`
 	End        Offset `json:"end"`
 	CurrentLag int64  `json:"current_lag"`
+	Owner      string `json:"owner"`
 }
 
 type ConsumerGroupStatusResp struct {

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -44,6 +44,7 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 				"cluster":   status.Status.Cluster,
 				"group":     status.Status.Group,
 				"topic":     partition.Topic,
+				"owner":     partition.Owner,
 				"partition": strconv.Itoa(int(partition.Partition)),
 			}).Set(float64(partition.CurrentLag))
 		}
@@ -53,6 +54,7 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 				"cluster":   status.Status.Cluster,
 				"group":     status.Status.Group,
 				"topic":     partition.Topic,
+				"owner":     partition.Owner,
 				"partition": strconv.Itoa(int(partition.Partition)),
 			}).Set(float64(partition.End.Offset))
 		}

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -19,14 +19,14 @@ var (
 			Name: "kafka_burrow_partition_lag",
 			Help: "The lag of the latest offset commit on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition"},
+		[]string{"cluster", "group", "topic", "partition", "owner"},
 	)
 	KafkaConsumerPartitionCurrentOffset = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_current_offset",
 			Help: "The latest offset commit on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition"},
+		[]string{"cluster", "group", "topic", "partition", "owner"},
 	)
 	KafkaConsumerPartitionCurrentStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
@jirwin I added in this commit for burrow_exporter to take the owner (member) of consumer group the burrow api, that was implemented in the last commit of burrow api. 
I changed also the version api default in the README for new version the burrow api.